### PR TITLE
(develop branch)문장 분리 엔진에서 개행 문자를 제거하고 공백을 대체하는 코드 변경사항입니다.

### DIFF
--- a/spacy_space/engine.py
+++ b/spacy_space/engine.py
@@ -75,7 +75,7 @@ class SplitEngine:
 
         text (str): non-splitted string of a single document.
         """
-        self.__document = text
+        self.__document = text.strip().replace("\n", " ")
         doc = self.nlp_engine(self.__document)
 
         self.__sentences = list() # ①


### PR DESCRIPTION
여러 줄의 string을 넣을 경우, 개행 문자로 시작하는 string이 들어가면 아래와 같이 오류가 발생합니다.
<img width="1150" alt="image" src="https://github.com/shhommychon/spacy-space/assets/7467605/11109764-a6cd-4cea-846d-a19d93daf5d7">

이 경우를 방지하고자 text 입력 시 앞뒤, 문장 내부의 개행문자를 제거하는 단순한 로직을 추가하는 것을 제안합니다.

<img width="1972" alt="image" src="https://github.com/shhommychon/spacy-space/assets/7467605/bf224367-c9c4-4a0d-9a7a-69e8aa9cb541">

감사합니다!